### PR TITLE
fix(xplane): harden TCAS traffic identity and altitude

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(CORE_SOURCES
     src/settings.cpp
     src/settings_ui.cpp
     src/simple_json.cpp
+    src/traffic_support.cpp
     src/udp_receiver.cpp
     src/udp_broadcaster.cpp
     src/msfs_bridge.cpp
@@ -92,6 +93,7 @@ set(HEADERS
     include/xp2gdl90/settings.h
     include/xp2gdl90/settings_ui.h
     include/xp2gdl90/simple_json.h
+    include/xp2gdl90/traffic_support.h
     include/xp2gdl90/udp_receiver.h
     include/xp2gdl90/udp_broadcaster.h
 )
@@ -389,6 +391,7 @@ if(XP2GDL90_BUILD_TESTS)
         tests/test_settings.cpp
         tests/test_settings_ui.cpp
         tests/test_simple_json.cpp
+        tests/test_traffic_support.cpp
         tests/test_udp_broadcaster.cpp
         tests/test_msfs_bridge.cpp
     )

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The current codebase includes:
 - ForeFlight ID and AHRS extension messages
 - ForeFlight auto-discovery with fallback to a manual target IP/port
 - Traffic broadcasting from TCAS targets, with legacy multiplayer fallback
+- Pressure-consistent traffic altitude and deterministic IDs for AI targets
+  that do not expose Mode-S addresses
 - An in-sim ImGui settings and status window
 - Cross-platform builds for macOS, Windows, and Linux
 - Experimental MSFS 2020/2024 ownship, AHRS, and best-effort traffic bridge on Windows
@@ -190,9 +192,16 @@ Current X-Plane behavior from the implementation:
 - ForeFlight auto-discovery is optional and listens on the configured broadcast port
 - Manual `target_ip` and `target_port` are used as the fallback target
 - The effective callsign uses the aircraft tail number when available, otherwise the configured fallback callsign
-- Ownship report altitude uses `sim/cockpit2/gauges/indicators/altitude_ft_pilot` when available
+- Ownship report altitude uses X-Plane's standard-atmosphere
+  `sim/flightmodel2/position/pressure_altitude` dataref when available
 - AHRS heading can be transmitted as true or magnetic heading
 - Traffic is sourced from TCAS target datarefs when available, otherwise from legacy multiplayer datarefs
+- Sparse AI targets without Mode-S identity receive deterministic GDL90 track
+  identities, including when identified and unidentified targets coexist
+- Empty TCAS slots marked with X-Plane's `-FLT_MAX` sentinel are discarded
+  instead of being emitted as phantom traffic
+- Traffic geometric altitude is shifted by the ownship pressure-minus-geometric
+  offset so displayed relative altitude remains consistent away from 29.92 inHg
 
 Weather uplink data is not transmitted.
 

--- a/include/xp2gdl90/traffic_support.h
+++ b/include/xp2gdl90/traffic_support.h
@@ -1,0 +1,32 @@
+#ifndef XP2GDL90_TRAFFIC_SUPPORT_H
+#define XP2GDL90_TRAFFIC_SUPPORT_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace xp2gdl90::traffic {
+
+struct TcasPresenceSample {
+  size_t slot = 0;
+  int raw_address = 0;
+  int ssr_mode = 0;
+  std::string callsign;
+  double local_x = 0.0;
+  double local_y = 0.0;
+  double local_z = 0.0;
+  double velocity_x = 0.0;
+  double velocity_y = 0.0;
+  double velocity_z = 0.0;
+};
+
+bool IsPopulatedTcasTarget(const TcasPresenceSample &sample);
+uint32_t SyntheticTrafficAddress(size_t slot, const std::string &callsign,
+                                 uint32_t ownship_address);
+int32_t CorrectGeometricToPressureAltitude(int32_t geometric_altitude_feet,
+                                           double ownship_geometric_feet,
+                                           double ownship_pressure_feet);
+
+} // namespace xp2gdl90::traffic
+
+#endif // XP2GDL90_TRAFFIC_SUPPORT_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "xp2gdl90/protocol_utils.h"
 #include "xp2gdl90/settings.h"
 #include "xp2gdl90/settings_ui.h"
+#include "xp2gdl90/traffic_support.h"
 #include "xp2gdl90/udp_broadcaster.h"
 #include "xp2gdl90/udp_receiver.h"
 
@@ -217,6 +218,7 @@ void DestroySettingsWindow();
 bool ReloadSettingsFromDisk();
 void SyncSettingsUiFromConfig();
 void InitializeTrafficDataRefs();
+int32_t CorrectTrafficAltitudeToPressure(int32_t geometric_altitude_feet);
 size_t CollectTrafficData(const Settings &cfg,
                           std::vector<gdl90::PositionData> *out_reports);
 void SendTrafficReports(float sim_time, const Settings &cfg);
@@ -511,7 +513,7 @@ std::string ReadTrafficFlightId(size_t slot) {
   return Trim(std::string(buffer));
 }
 
-std::string ReadTrafficCallsign(size_t slot, uint32_t address) {
+std::string ReadTrafficIdentity(size_t slot) {
   std::string callsign =
       xp2gdl90::protocol::SanitizeCallsign(ReadTrafficFlightId(slot));
   if (callsign.empty() && slot >= 1 &&
@@ -522,7 +524,7 @@ std::string ReadTrafficCallsign(size_t slot, uint32_t address) {
   if (!callsign.empty()) {
     return callsign;
   }
-  return FormatTrafficFallbackCallsign(address);
+  return "";
 }
 
 uint16_t CalculateHorizontalSpeedKnots(float vx, float vz) {
@@ -550,23 +552,12 @@ bool BuildTrafficReportFromTcasSlot(const Settings &cfg, size_t slot,
   const int slot_index = ClampFloatToInt<int>(slot);
   const int raw_address =
       ReadIntArrayValue(g_state.traffic_tcas_refs.mode_s_ref, slot_index, 0);
-  const uint32_t address = NormalizeTcasAddress(raw_address);
-  if (address == 0u) {
-    return false;
-  }
-
   const float local_x =
       ReadFloatArrayValue(g_state.traffic_tcas_refs.x_ref, slot_index, NAN);
   const float local_y =
       ReadFloatArrayValue(g_state.traffic_tcas_refs.y_ref, slot_index, NAN);
   const float local_z =
       ReadFloatArrayValue(g_state.traffic_tcas_refs.z_ref, slot_index, NAN);
-
-  gdl90::PositionData report{};
-  if (!LocalPositionToWorld(local_x, local_y, local_z, &report.latitude,
-                            &report.longitude, &report.altitude)) {
-    return false;
-  }
 
   const float vx =
       ReadFloatArrayValue(g_state.traffic_tcas_refs.vx_ref, slot_index, NAN);
@@ -586,6 +577,39 @@ bool BuildTrafficReportFromTcasSlot(const Settings &cfg, size_t slot,
       g_state.traffic_tcas_refs.mode_c_code_ref, slot_index, 0);
   const int wake_category =
       ReadIntArrayValue(g_state.traffic_tcas_refs.wake_cat_ref, slot_index, -1);
+  const std::string identity = ReadTrafficIdentity(slot);
+
+  xp2gdl90::traffic::TcasPresenceSample presence;
+  presence.slot = slot;
+  presence.raw_address = raw_address;
+  presence.ssr_mode = ssr_mode;
+  presence.callsign = identity;
+  presence.local_x = local_x;
+  presence.local_y = local_y;
+  presence.local_z = local_z;
+  presence.velocity_x = vx;
+  presence.velocity_y = vy;
+  presence.velocity_z = vz;
+  if (!xp2gdl90::traffic::IsPopulatedTcasTarget(presence)) {
+    return false;
+  }
+
+  uint32_t address = NormalizeTcasAddress(raw_address);
+  const bool synthetic_address = address == 0u;
+  if (synthetic_address) {
+    address = xp2gdl90::traffic::SyntheticTrafficAddress(slot, identity,
+                                                         cfg.icao_address);
+  }
+  if (address == (cfg.icao_address & 0xFFFFFFu)) {
+    return false;
+  }
+
+  gdl90::PositionData report{};
+  if (!LocalPositionToWorld(local_x, local_y, local_z, &report.latitude,
+                            &report.longitude, &report.altitude)) {
+    return false;
+  }
+  report.altitude = CorrectTrafficAltitudeToPressure(report.altitude);
 
   const bool airborne = (weight_on_wheels >= 0)
                             ? (weight_on_wheels == 0)
@@ -604,9 +628,11 @@ bool BuildTrafficReportFromTcasSlot(const Settings &cfg, size_t slot,
   report.nic = cfg.nic;
   report.nacp = cfg.nacp;
   report.icao_address = address;
-  report.callsign = ReadTrafficCallsign(slot, report.icao_address);
+  report.callsign =
+      identity.empty() ? FormatTrafficFallbackCallsign(address) : identity;
   report.emitter_category = WakeCategoryToEmitterCategory(wake_category);
-  report.address_type = ResolveTcasAddressType(raw_address);
+  report.address_type = synthetic_address ? gdl90::AddressType::TISB_TRACK_FILE
+                                          : ResolveTcasAddressType(raw_address);
   report.alert_status = 0;
   report.emergency_code = ResolveTrafficEmergencyCodeFromSquawk(squawk);
 
@@ -633,9 +659,12 @@ bool BuildTrafficReportFromLegacySlot(const Settings &cfg, size_t slot,
   const float vz = XPLMGetDataf(refs.vz_ref);
   const float heading = XPLMGetDataf(refs.heading_ref);
 
-  const uint32_t synthetic_address = static_cast<uint32_t>(
-      0xF00000u | (static_cast<uint32_t>(slot) & 0xFFFFu));
-  const std::string callsign = ReadTrafficCallsign(slot, synthetic_address);
+  const std::string identity = ReadTrafficIdentity(slot);
+  const uint32_t synthetic_address = xp2gdl90::traffic::SyntheticTrafficAddress(
+      slot, identity, cfg.icao_address);
+  const std::string callsign =
+      identity.empty() ? FormatTrafficFallbackCallsign(synthetic_address)
+                       : identity;
 
   if (!std::isfinite(static_cast<double>(local_x)) ||
       !std::isfinite(static_cast<double>(local_y)) ||
@@ -652,6 +681,7 @@ bool BuildTrafficReportFromLegacySlot(const Settings &cfg, size_t slot,
                             &report.longitude, &report.altitude)) {
     return false;
   }
+  report.altitude = CorrectTrafficAltitudeToPressure(report.altitude);
 
   report.h_velocity = CalculateHorizontalSpeedKnots(vx, vz);
   report.v_velocity = CalculateVerticalSpeedFpm(vy);
@@ -694,6 +724,17 @@ bool VerifyDataRef(XPLMDataRef ref, const char *name) {
   }
   LogMessage(std::string("ERROR: Missing dataref ") + name);
   return false;
+}
+
+int32_t CorrectTrafficAltitudeToPressure(int32_t geometric_altitude_feet) {
+  if (!g_state.alt_ref || !g_state.pressure_alt_ref) {
+    return geometric_altitude_feet;
+  }
+  const double ownship_geometric_feet =
+      XPLMGetDatad(g_state.alt_ref) * kMetersToFeet;
+  const double ownship_pressure_feet = XPLMGetDatad(g_state.pressure_alt_ref);
+  return xp2gdl90::traffic::CorrectGeometricToPressureAltitude(
+      geometric_altitude_feet, ownship_geometric_feet, ownship_pressure_feet);
 }
 
 bool ReconfigureRuntimeReceivers(const Settings &cfg, std::string *out_error) {
@@ -793,7 +834,7 @@ gdl90::PositionData GetOwnshipData(const Settings &cfg) {
 
   if (g_state.pressure_alt_ref) {
     data.altitude =
-        ClampFloatToInt<int32_t>(XPLMGetDataf(g_state.pressure_alt_ref));
+        ClampFloatToInt<int32_t>(XPLMGetDatad(g_state.pressure_alt_ref));
   } else {
     data.altitude = std::numeric_limits<int32_t>::min();
   }
@@ -1782,7 +1823,7 @@ PLUGIN_API int XPluginStart(char *outName, char *outSig, char *outDesc) {
   g_state.lon_ref = XPLMFindDataRef("sim/flightmodel/position/longitude");
   g_state.alt_ref = XPLMFindDataRef("sim/flightmodel/position/elevation");
   g_state.pressure_alt_ref =
-      XPLMFindDataRef("sim/cockpit2/gauges/indicators/altitude_ft_pilot");
+      XPLMFindDataRef("sim/flightmodel2/position/pressure_altitude");
   g_state.speed_ref = XPLMFindDataRef("sim/flightmodel/position/groundspeed");
   g_state.track_ref = XPLMFindDataRef("sim/flightmodel/position/true_psi");
   g_state.pitch_ref = XPLMFindDataRef("sim/flightmodel/position/theta");

--- a/src/traffic_support.cpp
+++ b/src/traffic_support.cpp
@@ -1,0 +1,93 @@
+#include "xp2gdl90/traffic_support.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace xp2gdl90::traffic {
+namespace {
+
+constexpr uint32_t kAddressMask = 0xFFFFFFu;
+constexpr uint32_t kSyntheticPrefix = 0xF00000u;
+constexpr double kPresenceEpsilon = 1e-6;
+// X-Plane fills unused TCAS float-array slots with -FLT_MAX. Local coordinates
+// are metres in the simulator's local frame, so this bound is deliberately far
+// beyond any usable target while still rejecting that finite sentinel.
+constexpr double kMaxLocalCoordinateMagnitude = 1.0e9;
+constexpr double kMaxVelocityMagnitude = 1.0e6;
+
+bool IsUsableMagnitude(double value, double maximum) {
+  return std::isfinite(value) && std::abs(value) < maximum;
+}
+
+bool HasMeaningfulMotion(double value) {
+  return IsUsableMagnitude(value, kMaxVelocityMagnitude) &&
+         std::abs(value) > kPresenceEpsilon;
+}
+
+} // namespace
+
+bool IsPopulatedTcasTarget(const TcasPresenceSample &sample) {
+  if (sample.slot == 0 ||
+      !IsUsableMagnitude(sample.local_x, kMaxLocalCoordinateMagnitude) ||
+      !IsUsableMagnitude(sample.local_y, kMaxLocalCoordinateMagnitude) ||
+      !IsUsableMagnitude(sample.local_z, kMaxLocalCoordinateMagnitude)) {
+    return false;
+  }
+
+  const uint32_t address =
+      static_cast<uint32_t>(sample.raw_address) & kAddressMask;
+  return address != 0u || !sample.callsign.empty() || sample.ssr_mode > 0 ||
+         std::abs(sample.local_x) > kPresenceEpsilon ||
+         std::abs(sample.local_y) > kPresenceEpsilon ||
+         std::abs(sample.local_z) > kPresenceEpsilon ||
+         HasMeaningfulMotion(sample.velocity_x) ||
+         HasMeaningfulMotion(sample.velocity_y) ||
+         HasMeaningfulMotion(sample.velocity_z);
+}
+
+uint32_t SyntheticTrafficAddress(size_t slot, const std::string &callsign,
+                                 uint32_t ownship_address) {
+  uint32_t hash = 2166136261u;
+  const auto mix = [&hash](uint8_t value) {
+    hash ^= value;
+    hash *= 16777619u;
+  };
+
+  // Prefer identity over array position so a target keeps its synthetic
+  // address when X-Plane or a traffic injector reorders TCAS slots.
+  if (!callsign.empty()) {
+    for (unsigned char value : callsign) {
+      mix(value);
+    }
+  } else {
+    for (size_t shift = 0; shift < sizeof(slot); ++shift) {
+      mix(static_cast<uint8_t>((slot >> (shift * 8u)) & 0xFFu));
+    }
+  }
+
+  uint32_t address = kSyntheticPrefix | (hash & 0x0FFFFFu);
+  if (address == (ownship_address & kAddressMask)) {
+    address = kSyntheticPrefix | ((address + 1u) & 0x0FFFFFu);
+  }
+  return address;
+}
+
+int32_t CorrectGeometricToPressureAltitude(int32_t geometric_altitude_feet,
+                                           double ownship_geometric_feet,
+                                           double ownship_pressure_feet) {
+  if (geometric_altitude_feet == std::numeric_limits<int32_t>::min() ||
+      !std::isfinite(ownship_geometric_feet) ||
+      !std::isfinite(ownship_pressure_feet)) {
+    return geometric_altitude_feet;
+  }
+
+  const double corrected = static_cast<double>(geometric_altitude_feet) +
+                           ownship_pressure_feet - ownship_geometric_feet;
+  const double low =
+      static_cast<double>(std::numeric_limits<int32_t>::min() + 1);
+  const double high = static_cast<double>(std::numeric_limits<int32_t>::max());
+  return static_cast<int32_t>((std::max)(low, (std::min)(high, corrected)));
+}
+
+} // namespace xp2gdl90::traffic

--- a/tests/test_traffic_support.cpp
+++ b/tests/test_traffic_support.cpp
@@ -1,0 +1,67 @@
+#include "test_harness.h"
+
+#include <limits>
+
+#include "xp2gdl90/traffic_support.h"
+
+TEST_CASE("TCAS presence rejects empty slots and accepts identity or motion") {
+  xp2gdl90::traffic::TcasPresenceSample sample;
+  sample.slot = 1;
+  sample.ssr_mode = -1;
+  ASSERT_TRUE(!xp2gdl90::traffic::IsPopulatedTcasTarget(sample));
+
+  sample.callsign = "AI01";
+  ASSERT_TRUE(xp2gdl90::traffic::IsPopulatedTcasTarget(sample));
+
+  sample.callsign.clear();
+  sample.velocity_x = 1.0;
+  ASSERT_TRUE(xp2gdl90::traffic::IsPopulatedTcasTarget(sample));
+}
+
+TEST_CASE("TCAS presence rejects invalid coordinates") {
+  xp2gdl90::traffic::TcasPresenceSample sample;
+  sample.slot = 2;
+  sample.raw_address = 0xABCDEF;
+  sample.local_x = std::numeric_limits<double>::quiet_NaN();
+  ASSERT_TRUE(!xp2gdl90::traffic::IsPopulatedTcasTarget(sample));
+
+  // X-Plane uses -FLT_MAX for every position component in an unused slot.
+  sample.local_x = -static_cast<double>(std::numeric_limits<float>::max());
+  sample.local_y = sample.local_x;
+  sample.local_z = sample.local_x;
+  ASSERT_TRUE(!xp2gdl90::traffic::IsPopulatedTcasTarget(sample));
+
+  sample.raw_address = 0;
+  sample.local_x = 0.0;
+  sample.local_y = 0.0;
+  sample.local_z = 0.0;
+  sample.velocity_x = -static_cast<double>(std::numeric_limits<float>::max());
+  ASSERT_TRUE(!xp2gdl90::traffic::IsPopulatedTcasTarget(sample));
+}
+
+TEST_CASE("Synthetic traffic addresses are stable and avoid ownship") {
+  const uint32_t first =
+      xp2gdl90::traffic::SyntheticTrafficAddress(3, "AAL123", 0xABCDEF);
+  ASSERT_EQ(first, xp2gdl90::traffic::SyntheticTrafficAddress(4, "AAL123", 0));
+  ASSERT_TRUE(first !=
+              xp2gdl90::traffic::SyntheticTrafficAddress(3, "UAL456", 0));
+
+  const uint32_t slot_only =
+      xp2gdl90::traffic::SyntheticTrafficAddress(3, "", 0);
+  ASSERT_TRUE(slot_only !=
+              xp2gdl90::traffic::SyntheticTrafficAddress(4, "", 0));
+
+  const uint32_t avoided =
+      xp2gdl90::traffic::SyntheticTrafficAddress(3, "AAL123", first);
+  ASSERT_TRUE(avoided != first);
+}
+
+TEST_CASE("Pressure correction preserves traffic relative altitude") {
+  ASSERT_EQ(4500, xp2gdl90::traffic::CorrectGeometricToPressureAltitude(
+                      5000, 1000.0, 500.0));
+  ASSERT_EQ(5000, xp2gdl90::traffic::CorrectGeometricToPressureAltitude(
+                      5000, std::numeric_limits<double>::quiet_NaN(), 500.0));
+  ASSERT_EQ(std::numeric_limits<int32_t>::min(),
+            xp2gdl90::traffic::CorrectGeometricToPressureAltitude(
+                std::numeric_limits<int32_t>::min(), 1000.0, 500.0));
+}


### PR DESCRIPTION
## Summary

- reject X-Plane's unused TCAS slot sentinels, including the finite `-FLT_MAX` value
- retain valid targets without Mode-S IDs by assigning deterministic TIS-B track-file addresses
- prevent ownship echoes and keep synthetic identities stable across slot reordering when a callsign is available
- use X-Plane's pressure-altitude dataref for ownship and pressure-correct traffic geometric altitude before GDL90 encoding

## Why

AI and multiplayer aircraft can have useful position data without a Mode-S ID. Dropping those slots hides traffic, while treating X-Plane's finite unused sentinel as real traffic creates bogus reports. GDL90 traffic altitude is pressure altitude, so sending raw geometric altitude can also create material vertical errors.

## Validation

- portable unit suite passes, including new sentinel, identity, echo-rejection, and pressure-correction coverage
- `src/main.cpp` passes a strict warnings-as-errors syntax build against the X-Plane SDK
- clang-format and whitespace checks pass

This PR is intentionally limited to traffic correctness and contains no deployment- or aicopilot-specific configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved traffic altitude reporting using pressure-altitude data for more consistent relative elevations.
  * Added deterministic identities for AI traffic targets, including targets without exposed Mode-S addresses.
  * Improved handling of sparse or empty TCAS slots to prevent phantom traffic reports.
  * Added clearer traffic callsigns and support for synthetic traffic addresses.

* **Documentation**
  * Updated the feature overview and runtime behavior documentation to describe the improved traffic handling and altitude corrections.

* **Tests**
  * Added coverage for traffic detection, identity generation, and altitude conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->