### PR TITLE
feat(xplane): configure traffic broadcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The X-Plane plugin and MSFS bridge send:
 - `0x00` Heartbeat at the configured `heartbeat_rate`
 - `0x0A` Ownship Report at the configured `position_rate`
 - `0x0B` Ownship Geometric Altitude at 1 Hz
-- `0x14` Traffic Report at 1 Hz
+- `0x14` Traffic Report at the configured `traffic_rate`
 - `0x65/0x00` ForeFlight ID at 1 Hz
 - `0x65/0x01` ForeFlight AHRS at 5 Hz
 
@@ -224,8 +224,11 @@ The on-disk settings file is JSON:
   "device_long_name": "XP2GDL90 AHRS",
   "internet_policy": 0,
   "ahrs_use_magnetic_heading": false,
+  "traffic_enabled": true,
   "heartbeat_rate": 1.0,
   "position_rate": 2.0,
+  "traffic_rate": 1.0,
+  "traffic_max_targets": 63,
   "nic": 11,
   "nacp": 11,
   "debug_logging": false,
@@ -248,8 +251,11 @@ Field reference:
 | `device_long_name` | string | ForeFlight long name. Trimmed to 16 characters. |
 | `internet_policy` | number | `0=Unrestricted`, `1=Expensive`, `2=Disallowed`. |
 | `ahrs_use_magnetic_heading` | boolean | `false` sends true heading, `true` converts to magnetic heading. |
+| `traffic_enabled` | boolean | Enables X-Plane TCAS/legacy traffic reports. |
 | `heartbeat_rate` | number | Must be greater than `0`. |
 | `position_rate` | number | Must be greater than `0`. |
+| `traffic_rate` | number | Traffic report sweep rate in Hz; must be greater than `0`. |
+| `traffic_max_targets` | number | Maximum sparse traffic slots to inspect, `0-63`. |
 | `nic` | number | Valid range `0-11`. `11` is recommended for EFB compatibility. |
 | `nacp` | number | Valid range `0-11`. `11` is recommended for EFB compatibility. |
 | `debug_logging` | boolean | Enables plugin debug logging to `Log.txt`. |

--- a/include/xp2gdl90/settings.h
+++ b/include/xp2gdl90/settings.h
@@ -18,9 +18,12 @@ struct Settings {
   std::string device_long_name = "XP2GDL90 AHRS";
   uint8_t internet_policy = 0;
   bool ahrs_use_magnetic_heading = false;
+  bool traffic_enabled = true;
 
   float heartbeat_rate = 1.0f;
   float position_rate = 2.0f;
+  float traffic_rate = 1.0f;
+  uint8_t traffic_max_targets = 63;
 
   uint8_t nic = 11;
   uint8_t nacp = 11;

--- a/include/xp2gdl90/settings_ui.h
+++ b/include/xp2gdl90/settings_ui.h
@@ -19,8 +19,11 @@ struct SettingsUiState {
   char device_long_name[64] = {};
   int internet_policy = 0;
   bool ahrs_use_magnetic_heading = false;
+  bool traffic_enabled = true;
   float heartbeat_rate = 0.0f;
   float position_rate = 0.0f;
+  float traffic_rate = 0.0f;
+  int traffic_max_targets = 0;
   int nic = 0;
   int nacp = 0;
   bool debug_logging = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,6 @@ namespace {
 constexpr double kMetersToFeet = 3.28084;
 constexpr float kMetersPerSecondToKnots = 1.94384f;
 constexpr float kMetersPerSecondToFeetPerMinute = 196.8504f;
-constexpr float kTrafficReportRate = 1.0f;
 constexpr float kForeFlightDeviceInfoRate = 1.0f;
 constexpr float kForeFlightAhrsRate = 5.0f;
 constexpr float kOwnshipGeoAltitudeRate = 1.0f;
@@ -978,16 +977,18 @@ void InitializeTrafficDataRefs() {
 
 size_t CollectTrafficData(const Settings &cfg,
                           std::vector<gdl90::PositionData> *out_reports) {
-  if (!out_reports) {
+  if (!out_reports || !cfg.traffic_enabled || cfg.traffic_max_targets == 0) {
     return 0;
   }
 
   out_reports->clear();
 
   if (g_state.traffic_tcas_refs.IsUsable()) {
-    out_reports->reserve(g_state.traffic_tcas_refs.slot_count);
-    for (size_t slot = 1; slot <= g_state.traffic_tcas_refs.slot_count;
-         ++slot) {
+    const size_t max_slots =
+        (std::min)(g_state.traffic_tcas_refs.slot_count,
+                   static_cast<size_t>(cfg.traffic_max_targets));
+    out_reports->reserve(max_slots);
+    for (size_t slot = 1; slot <= max_slots; ++slot) {
       gdl90::PositionData report{};
       if (BuildTrafficReportFromTcasSlot(cfg, slot, &report)) {
         out_reports->push_back(report);
@@ -999,8 +1000,11 @@ size_t CollectTrafficData(const Settings &cfg,
     return out_reports->size();
   }
 
-  out_reports->reserve(g_state.legacy_traffic_refs.size());
-  for (size_t slot = 1; slot <= g_state.legacy_traffic_refs.size(); ++slot) {
+  const size_t max_slots =
+      (std::min)(g_state.legacy_traffic_refs.size(),
+                 static_cast<size_t>(cfg.traffic_max_targets));
+  out_reports->reserve(max_slots);
+  for (size_t slot = 1; slot <= max_slots; ++slot) {
     gdl90::PositionData report{};
     if (BuildTrafficReportFromLegacySlot(cfg, slot, &report)) {
       out_reports->push_back(report);
@@ -1011,7 +1015,8 @@ size_t CollectTrafficData(const Settings &cfg,
 }
 
 void SendTrafficReports(float sim_time, const Settings &cfg) {
-  if (sim_time - g_state.last_traffic < (1.0f / kTrafficReportRate)) {
+  if (!cfg.traffic_enabled || cfg.traffic_rate <= 0.0f ||
+      sim_time - g_state.last_traffic < (1.0f / cfg.traffic_rate)) {
     return;
   }
 
@@ -1354,6 +1359,14 @@ void DrawSettingsWindowUI() {
       dirty_now |= ImGui::InputFloat("Position Rate (Hz)",
                                      &g_state.settings_ui.position_rate, 0.1f,
                                      1.0f, "%.2f");
+      dirty_now |= ImGui::Checkbox("Broadcast traffic",
+                                   &g_state.settings_ui.traffic_enabled);
+      dirty_now |= ImGui::InputFloat("Traffic Rate (Hz)",
+                                     &g_state.settings_ui.traffic_rate, 0.1f,
+                                     1.0f, "%.2f");
+      dirty_now |= ImGui::InputInt("Traffic Maximum",
+                                   &g_state.settings_ui.traffic_max_targets);
+      ImGui::TextUnformatted("Traffic maximum range: 0-63 targets");
       ImGui::EndTabItem();
     }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -146,10 +146,23 @@ bool LoadSettingsFromJsonFile(const std::string &path, Settings *out_settings,
   if (ReadPositiveRate(root.Find("position_rate"), &rate)) {
     settings.position_rate = rate;
   }
+  if (ReadPositiveRate(root.Find("traffic_rate"), &rate)) {
+    settings.traffic_rate = rate;
+  }
+
+  if (const json::Value *value = root.Find("traffic_max_targets");
+      value && value->IsNumber() && std::isfinite(value->number_value) &&
+      value->number_value >= 0.0 && value->number_value <= 63.0) {
+    settings.traffic_max_targets = static_cast<uint8_t>(value->number_value);
+  }
 
   if (const json::Value *value = root.Find("ahrs_use_magnetic_heading");
       value && value->IsBool()) {
     settings.ahrs_use_magnetic_heading = value->bool_value;
+  }
+  if (const json::Value *value = root.Find("traffic_enabled");
+      value && value->IsBool()) {
+    settings.traffic_enabled = value->bool_value;
   }
   if (const json::Value *value = root.Find("debug_logging");
       value && value->IsBool()) {
@@ -208,8 +221,13 @@ bool SaveSettingsToJsonFile(const std::string &path, const Settings &settings,
        << static_cast<unsigned int>(settings.internet_policy) << ",\n";
   file << "  \"ahrs_use_magnetic_heading\": "
        << (settings.ahrs_use_magnetic_heading ? "true" : "false") << ",\n";
+  file << "  \"traffic_enabled\": "
+       << (settings.traffic_enabled ? "true" : "false") << ",\n";
   file << "  \"heartbeat_rate\": " << settings.heartbeat_rate << ",\n";
   file << "  \"position_rate\": " << settings.position_rate << ",\n";
+  file << "  \"traffic_rate\": " << settings.traffic_rate << ",\n";
+  file << "  \"traffic_max_targets\": "
+       << static_cast<unsigned int>(settings.traffic_max_targets) << ",\n";
   file << "  \"nic\": " << static_cast<unsigned int>(settings.nic) << ",\n";
   file << "  \"nacp\": " << static_cast<unsigned int>(settings.nacp) << ",\n";
   file << "  \"debug_logging\": " << (settings.debug_logging ? "true" : "false")

--- a/src/settings_ui.cpp
+++ b/src/settings_ui.cpp
@@ -73,8 +73,12 @@ void SyncSettingsUiFromConfig(SettingsUiState *ui_state,
                 "%s", settings.device_long_name.c_str());
   ui_state->internet_policy = static_cast<int>(settings.internet_policy);
   ui_state->ahrs_use_magnetic_heading = settings.ahrs_use_magnetic_heading;
+  ui_state->traffic_enabled = settings.traffic_enabled;
   ui_state->heartbeat_rate = settings.heartbeat_rate;
   ui_state->position_rate = settings.position_rate;
+  ui_state->traffic_rate = settings.traffic_rate;
+  ui_state->traffic_max_targets =
+      static_cast<int>(settings.traffic_max_targets);
   ui_state->nic = static_cast<int>(settings.nic);
   ui_state->nacp = static_cast<int>(settings.nacp);
   ui_state->debug_logging = settings.debug_logging;
@@ -160,6 +164,7 @@ bool BuildConfigFromSettingsUi(const SettingsUiState &ui_state,
   }
   settings.internet_policy = static_cast<uint8_t>(ui_state.internet_policy);
   settings.ahrs_use_magnetic_heading = ui_state.ahrs_use_magnetic_heading;
+  settings.traffic_enabled = ui_state.traffic_enabled;
 
   if (ui_state.heartbeat_rate <= 0.0f) {
     if (out_error) {
@@ -176,6 +181,23 @@ bool BuildConfigFromSettingsUi(const SettingsUiState &ui_state,
     return false;
   }
   settings.position_rate = ui_state.position_rate;
+
+  if (ui_state.traffic_rate <= 0.0f) {
+    if (out_error) {
+      *out_error = "Traffic rate must be > 0";
+    }
+    return false;
+  }
+  settings.traffic_rate = ui_state.traffic_rate;
+
+  if (ui_state.traffic_max_targets < 0 || ui_state.traffic_max_targets > 63) {
+    if (out_error) {
+      *out_error = "Traffic maximum must be 0-63";
+    }
+    return false;
+  }
+  settings.traffic_max_targets =
+      static_cast<uint8_t>(ui_state.traffic_max_targets);
 
   if (ui_state.nic < 0 || ui_state.nic > 11) {
     if (out_error) {

--- a/tests/test_settings.cpp
+++ b/tests/test_settings.cpp
@@ -45,8 +45,11 @@ TEST_CASE("Settings save and load round-trip through JSON") {
   saved.device_long_name = "Bridge Device";
   saved.internet_policy = 2;
   saved.ahrs_use_magnetic_heading = true;
+  saved.traffic_enabled = false;
   saved.heartbeat_rate = 3.5f;
   saved.position_rate = 1.25f;
+  saved.traffic_rate = 2.0f;
+  saved.traffic_max_targets = 17;
   saved.nic = 10;
   saved.nacp = 9;
   saved.debug_logging = true;
@@ -72,8 +75,11 @@ TEST_CASE("Settings save and load round-trip through JSON") {
   ASSERT_EQ(saved.device_long_name, loaded.device_long_name);
   ASSERT_EQ(saved.internet_policy, loaded.internet_policy);
   ASSERT_EQ(saved.ahrs_use_magnetic_heading, loaded.ahrs_use_magnetic_heading);
+  ASSERT_EQ(saved.traffic_enabled, loaded.traffic_enabled);
   ASSERT_EQ(saved.heartbeat_rate, loaded.heartbeat_rate);
   ASSERT_EQ(saved.position_rate, loaded.position_rate);
+  ASSERT_EQ(saved.traffic_rate, loaded.traffic_rate);
+  ASSERT_EQ(saved.traffic_max_targets, loaded.traffic_max_targets);
   ASSERT_EQ(saved.nic, loaded.nic);
   ASSERT_EQ(saved.nacp, loaded.nacp);
   ASSERT_EQ(saved.debug_logging, loaded.debug_logging);
@@ -103,6 +109,9 @@ TEST_CASE("Settings loader ignores invalid values and unknown keys") {
        << "  \"target_ip\": \"999.168.0.10\",\n"
        << "  \"target_port\": 70000,\n"
        << "  \"emitter_category\": 99,\n"
+       << "  \"traffic_enabled\": \"yes\",\n"
+       << "  \"traffic_rate\": 0,\n"
+       << "  \"traffic_max_targets\": 64,\n"
        << "  \"nic\": 12,\n"
        << "  \"nacp\": 15,\n"
        << "  \"debug_logging\": true,\n"
@@ -115,6 +124,9 @@ TEST_CASE("Settings loader ignores invalid values and unknown keys") {
   loaded.target_ip = "192.168.0.20";
   loaded.target_port = 4000;
   loaded.emitter_category = 1;
+  loaded.traffic_enabled = true;
+  loaded.traffic_rate = 1.0f;
+  loaded.traffic_max_targets = 63;
   loaded.nic = 11;
   loaded.nacp = 11;
 
@@ -126,6 +138,9 @@ TEST_CASE("Settings loader ignores invalid values and unknown keys") {
   ASSERT_EQ(std::string("192.168.0.20"), loaded.target_ip);
   ASSERT_EQ(static_cast<uint16_t>(4000), loaded.target_port);
   ASSERT_EQ(static_cast<uint8_t>(1), loaded.emitter_category);
+  ASSERT_TRUE(loaded.traffic_enabled);
+  ASSERT_EQ(1.0f, loaded.traffic_rate);
+  ASSERT_EQ(static_cast<uint8_t>(63), loaded.traffic_max_targets);
   ASSERT_EQ(static_cast<uint8_t>(11), loaded.nic);
   ASSERT_EQ(static_cast<uint8_t>(11), loaded.nacp);
   ASSERT_TRUE(loaded.debug_logging);
@@ -149,6 +164,9 @@ TEST_CASE(
        << "  \"internet_policy\": 1,\n"
        << "  \"heartbeat_rate\": 4.0,\n"
        << "  \"position_rate\": 2.0,\n"
+       << "  \"traffic_enabled\": false,\n"
+       << "  \"traffic_rate\": 2.5,\n"
+       << "  \"traffic_max_targets\": 31,\n"
        << "  \"nic\": 10,\n"
        << "  \"nacp\": 9,\n"
        << "  \"ahrs_use_magnetic_heading\": true,\n"
@@ -172,6 +190,9 @@ TEST_CASE(
   ASSERT_EQ(static_cast<uint8_t>(1), loaded.internet_policy);
   ASSERT_EQ(4.0f, loaded.heartbeat_rate);
   ASSERT_EQ(2.0f, loaded.position_rate);
+  ASSERT_TRUE(!loaded.traffic_enabled);
+  ASSERT_EQ(2.5f, loaded.traffic_rate);
+  ASSERT_EQ(static_cast<uint8_t>(31), loaded.traffic_max_targets);
   ASSERT_EQ(static_cast<uint8_t>(10), loaded.nic);
   ASSERT_EQ(static_cast<uint8_t>(9), loaded.nacp);
   ASSERT_TRUE(loaded.ahrs_use_magnetic_heading);

--- a/tests/test_settings_ui.cpp
+++ b/tests/test_settings_ui.cpp
@@ -18,8 +18,11 @@ TEST_CASE("Settings UI sync reflects config values") {
   settings.device_long_name = "XP Test Device";
   settings.internet_policy = 1;
   settings.ahrs_use_magnetic_heading = true;
+  settings.traffic_enabled = false;
   settings.heartbeat_rate = 5.0f;
   settings.position_rate = 2.5f;
+  settings.traffic_rate = 1.5f;
+  settings.traffic_max_targets = 23;
   settings.nic = 10;
   settings.nacp = 9;
   settings.debug_logging = true;
@@ -40,8 +43,11 @@ TEST_CASE("Settings UI sync reflects config values") {
             std::string(ui_state.device_long_name));
   ASSERT_EQ(1, ui_state.internet_policy);
   ASSERT_TRUE(ui_state.ahrs_use_magnetic_heading);
+  ASSERT_TRUE(!ui_state.traffic_enabled);
   ASSERT_EQ(5.0f, ui_state.heartbeat_rate);
   ASSERT_EQ(2.5f, ui_state.position_rate);
+  ASSERT_EQ(1.5f, ui_state.traffic_rate);
+  ASSERT_EQ(23, ui_state.traffic_max_targets);
   ASSERT_EQ(10, ui_state.nic);
   ASSERT_EQ(9, ui_state.nacp);
   ASSERT_TRUE(ui_state.debug_logging);
@@ -59,6 +65,9 @@ TEST_CASE("Settings UI defaults mirror default config") {
   ASSERT_TRUE(ui_state.foreflight_auto_discovery);
   ASSERT_EQ(63093, ui_state.foreflight_broadcast_port);
   ASSERT_EQ(std::string("0xABCDEF"), std::string(ui_state.icao_address));
+  ASSERT_TRUE(ui_state.traffic_enabled);
+  ASSERT_EQ(1.0f, ui_state.traffic_rate);
+  ASSERT_EQ(63, ui_state.traffic_max_targets);
 }
 
 TEST_CASE("Settings UI builder validates fields and trims text") {
@@ -77,8 +86,11 @@ TEST_CASE("Settings UI builder validates fields and trims text") {
                 " Long Device Name ");
   ui_state.internet_policy = 2;
   ui_state.ahrs_use_magnetic_heading = true;
+  ui_state.traffic_enabled = true;
   ui_state.heartbeat_rate = 2.0f;
   ui_state.position_rate = 1.0f;
+  ui_state.traffic_rate = 1.5f;
+  ui_state.traffic_max_targets = 42;
   ui_state.nic = 11;
   ui_state.nacp = 10;
   ui_state.debug_logging = true;
@@ -96,6 +108,9 @@ TEST_CASE("Settings UI builder validates fields and trims text") {
   ASSERT_EQ(static_cast<uint8_t>(7), built.emitter_category);
   ASSERT_EQ(static_cast<uint8_t>(2), built.internet_policy);
   ASSERT_TRUE(built.ahrs_use_magnetic_heading);
+  ASSERT_TRUE(built.traffic_enabled);
+  ASSERT_EQ(1.5f, built.traffic_rate);
+  ASSERT_EQ(static_cast<uint8_t>(42), built.traffic_max_targets);
 }
 
 TEST_CASE("Settings UI builder requires output settings object") {
@@ -118,6 +133,8 @@ TEST_CASE("Settings UI builder rejects invalid numeric ranges") {
   ui_state.internet_policy = 0;
   ui_state.heartbeat_rate = 1.0f;
   ui_state.position_rate = 1.0f;
+  ui_state.traffic_rate = 1.0f;
+  ui_state.traffic_max_targets = 63;
   ui_state.nic = 11;
   ui_state.nacp = 11;
 
@@ -191,6 +208,18 @@ TEST_CASE(
   ASSERT_TRUE(!xp2gdl90::BuildConfigFromSettingsUi(
       ui_state, xp2gdl90::Settings{}, &built, &error));
   ASSERT_TRUE(error.find("Position rate must be > 0") != std::string::npos);
+
+  xp2gdl90::LoadDefaultSettingsUiState(&ui_state);
+  ui_state.traffic_rate = 0.0f;
+  ASSERT_TRUE(!xp2gdl90::BuildConfigFromSettingsUi(
+      ui_state, xp2gdl90::Settings{}, &built, &error));
+  ASSERT_TRUE(error.find("Traffic rate must be > 0") != std::string::npos);
+
+  xp2gdl90::LoadDefaultSettingsUiState(&ui_state);
+  ui_state.traffic_max_targets = 64;
+  ASSERT_TRUE(!xp2gdl90::BuildConfigFromSettingsUi(
+      ui_state, xp2gdl90::Settings{}, &built, &error));
+  ASSERT_TRUE(error.find("Traffic maximum must be 0-63") != std::string::npos);
 
   xp2gdl90::LoadDefaultSettingsUiState(&ui_state);
   ui_state.nic = 12;


### PR DESCRIPTION
## Summary

- add persisted settings to enable/disable traffic broadcasts
- make the traffic update rate configurable
- make the maximum number of targets per update configurable, capped at the GDL90/X-Plane limit
- expose the controls and active values in the in-simulator settings/status UI

## Why

Traffic output currently has fixed runtime behavior. These controls let users tune network/update load and disable simulated traffic when another source is authoritative, while preserving the existing behavior through defaults (`enabled`, 1 Hz, 63 targets).

## Validation

- settings JSON round-trip and invalid-value handling are covered
- settings UI synchronization, defaults, and range validation are covered
- complete portable unit suite passes
- `src/main.cpp` passes a strict warnings-as-errors syntax build against the X-Plane SDK
- clang-format and whitespace checks pass

This PR changes configuration only; traffic identity/altitude correctness is proposed separately.