### PR TITLE
build(windows): support MinGW plugin builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,44 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  build-windows-mingw:
+    name: Build Windows (MinGW)
+    needs: format
+    runs-on: windows-2022
+
+    steps:
+      - run: git config --global core.autocrlf input
+
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Setup MinGW
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+
+      - name: Configure, build, and test
+        shell: msys2 {0}
+        run: |
+          cmake -S . -B build-mingw -G Ninja \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -DXP2GDL90_BUILD_TESTS=ON
+          cmake --build build-mingw
+          ctest --test-dir build-mingw --output-on-failure
+
+      - name: Verify plugin exports
+        shell: msys2 {0}
+        run: |
+          test -f build-mingw/win.xpl
+          objdump -p build-mingw/win.xpl | grep -q XPluginStart
+          objdump -p build-mingw/win.xpl | grep -q XPluginStop
+
   build-macos:
     name: Build macOS
     needs: format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,9 @@ elseif(WIN32)
     add_library(${PLUGIN_NAME} MODULE ${PLUGIN_SOURCES} ${IMGUI_SOURCES})
     if(MSVC)
         set_msvc_runtime(${PLUGIN_NAME})
+    else()
+        # Keep LLVM-MinGW/MinGW builds self-contained for X-Plane deployment.
+        target_link_options(${PLUGIN_NAME} PRIVATE -static)
     endif()
     
     # Set output name
@@ -217,10 +220,13 @@ elseif(WIN32)
         opengl32
     )
     
-    # Export symbols
-    set_target_properties(${PLUGIN_NAME} PROPERTIES
-        LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/win_exports.def"
-    )
+    # MSVC consumes the module-definition file directly. MinGW exports the
+    # PLUGIN_API entry points declared by the X-Plane SDK headers.
+    if(MSVC)
+        set_target_properties(${PLUGIN_NAME} PROPERTIES
+            LINK_FLAGS "/DEF:${CMAKE_CURRENT_SOURCE_DIR}/win_exports.def"
+        )
+    endif()
     
 elseif(UNIX AND NOT APPLE)
     # ====== Linux Configuration ======
@@ -393,6 +399,12 @@ if(XP2GDL90_BUILD_TESTS)
         tests/test_msfs_bridge.cpp
     )
     target_link_libraries(xp2gdl90_tests PRIVATE xp2gdl90_core)
+    if(WIN32)
+        target_link_libraries(xp2gdl90_tests PRIVATE ws2_32)
+        if(NOT MSVC)
+            target_link_options(xp2gdl90_tests PRIVATE -static)
+        endif()
+    endif()
     xp2gdl90_enable_coverage(xp2gdl90_tests)
     if(XP2GDL90_ENABLE_SOCKET_OPS_TESTS)
         target_compile_definitions(xp2gdl90_tests PRIVATE XP2GDL90_ENABLE_SOCKET_OPS_TESTS=1)


### PR DESCRIPTION
## Summary

- support building the Windows X-Plane plugin with LLVM-MinGW/MinGW
- retain the existing MSVC module-definition and runtime behavior
- statically link MinGW runtime libraries for a self-contained plugin
- link the Windows socket library into the test target
- add a Windows UCRT64 MinGW CI job that builds, tests, and verifies X-Plane entry-point exports

## Why

The previous CMake path passes the MSVC-only `/DEF:` option to non-MSVC linkers, omits `ws2_32` from Windows tests, and can leave compiler-runtime DLL dependencies beside the plugin. These changes keep the MSVC path unchanged while making the portable Windows path reproducible.

## Validation

- local LLVM-MinGW build produced both `win.xpl` and `xp2gdl90_tests.exe`
- all five required X-Plane plugin entry points were verified in the PE export table
- the native Windows unit suite and strict Linux/GCC unit suite pass
- GitHub Actions passed: MinGW, MSVC/MSFS, Linux, macOS, and formatting

CI evidence: https://github.com/ellisrakins/xp2gdl90/actions/runs/29630842721